### PR TITLE
Truffle 5 compatibility fix for measuring gas

### DIFF
--- a/gas/testGas.js
+++ b/gas/testGas.js
@@ -89,9 +89,16 @@ function createGasStatCollectorBeforeHook(contracts) {
 
         const originalAt = contract.at;
         contract.at = function() {
-          const instance = originalAt.apply(this, arguments);
-          setupProxiesForGasStats(instance, contract.gasStats);
-          return instance;
+          const instanceQ = originalAt.apply(this, arguments);
+          if(typeof instanceQ.abi !== 'undefined') {
+            setupProxiesForGasStats(instanceQ, contract.gasStats);
+            return instanceQ;
+          } else {
+            return instanceQ.then(instance => (
+              setupProxiesForGasStats(instance, contract.gasStats),
+              instance
+            ));
+          }
         };
 
         const originalNew = contract.new;

--- a/test/fixtures/basic-truffle-project/test/basic-thing.js
+++ b/test/fixtures/basic-truffle-project/test/basic-thing.js
@@ -9,5 +9,7 @@ contract('BasicThing', function(accounts) {
   it('checks the thing at the beginning', async () => {
     const basicThing = await BasicThing.deployed()
     assert(await basicThing.checkTheThing())
+    const basicThingCopy = await BasicThing.at(basicThing.address)
+    assert(await basicThingCopy.checkTheThing())
   })
 })


### PR DESCRIPTION
Due to Truffle 5 removing synchronous `.at`, the instrumentation step was failing.